### PR TITLE
Add EVD_py for use in closig

### DIFF
--- a/greg/linking.py
+++ b/greg/linking.py
@@ -16,11 +16,12 @@ def EMI(C_obs, G=None, corr=True):
     if G is not None:
         assert G.shape == C_shape
     P = C_shape[-1]
-    if C_shape[-2] != P: raise ValueError('G needs to be square')
+    if C_shape[-2] != P:
+        raise ValueError('G needs to be square')
     C_obs = C_obs.reshape((-1, P, P))
     if G is None:
         G = force_doubly_nonnegative(np.abs(C_obs).real, inplace=True)
-    G = G.reshape((-1, P, P))    
+    G = G.reshape((-1, P, P))
     if corr:
         G = correlation(G, inplace=False)
         C_obs = correlation(C_obs, inplace=False)
@@ -35,22 +36,50 @@ def EMI_py(C_obs, G=None, corr=True):
     if G is not None:
         assert G.shape == C_shape
     P = C_shape[-1]
-    if C_shape[-2] != P: raise ValueError('G needs to be square')
+    if C_shape[-2] != P:
+        raise ValueError('G needs to be square')
     C_obs = C_obs.reshape((-1, P, P))
     if G is None:
         G = force_doubly_nonnegative_py(np.abs(C_obs).real)
     G = G.reshape((-1, P, P))
-    N = G.shape[0]    
+    N = G.shape[0]
     if corr:
         G = correlation(G, inplace=False)
         C_obs = correlation(C_obs, inplace=False)
     ceig = np.empty((N, P), dtype=np.complex128)
     for n in range(N):
-        had = C_obs[n,:,:]
-        had *= np.linalg.pinv(G[n,:,:])
+        had = C_obs[n, :, :]
+        had *= np.linalg.pinv(G[n, :, :])
         _, ceig_n = eigh(
             had, subset_by_index=[0, 0], eigvals_only=False)
-        ceig[n,:] = ceig_n[:, 0] * (ceig_n[0, 0].conj() / np.abs(ceig_n[0, 0]))
+        ceig[n, :] = ceig_n[:, 0] * \
+            (ceig_n[0, 0].conj() / np.abs(ceig_n[0, 0]))
+    return ceig.reshape(C_shape[:-1])
+
+
+def EVD_py(C_obs, G=None, corr=True):
+    from scipy.linalg import eigh
+    C_shape = C_obs.shape
+    if G is not None:
+        assert G.shape == C_shape
+    P = C_shape[-1]
+    if C_shape[-2] != P:
+        raise ValueError('G needs to be square')
+    C_obs = C_obs.reshape((-1, P, P))
+    if G is None:
+        C_shape
+        G = force_doubly_nonnegative_py(np.abs(C_obs).real)
+    G = G.reshape((-1, P, P))
+    N = G.shape[0]
+    if corr:
+        G = correlation(G, inplace=False)
+        C_obs = correlation(C_obs, inplace=False)
+    ceig = np.empty((N, P), dtype=np.complex128)
+    for n in range(N):
+        _, ceig_n = eigh(C_obs[n, :, :], subset_by_index=[
+                         P-1, P-1], eigvals_only=False)
+        ceig[n, :] = ceig_n[:, 0] * \
+            (ceig_n[0, 0].conj() / np.abs(ceig_n[0, 0]))
     return ceig.reshape(C_shape[:-1])
 
 


### PR DESCRIPTION
EVD works better for simulating biases in SBAS networks. The EVD implemented here is only slightly modified from the EMI_py function. In the future, it may be worthwhile restructuring the functions to share the base code so consistency is guaranteed with changes, but I don't want to alter anything too dramatically right now.